### PR TITLE
windows fix - excludePaths are ignored mids/paths

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -40,7 +40,7 @@ else {
 			})();
 
 			packagePaths.forEach(function processPath(parent, path) {
-				path = pathUtil.join(parent, path);
+				path = pathUtil.join(parent, path).replace(/\\/g, '/'); //windows fix
 				var stats;
 
 				try {


### PR DESCRIPTION
Fix windows paths so excludePaths regex mids are not ingored, forward slash vs backslash
#### Documentation also needs to be updated for Windows users

Windows users (using a command prompt, not msysgit) should add quotes around the arguments for the batch file, see http://dojo-toolkit.33424.n3.nabble.com/js-doc-parse-TypeError-occurs-when-quot-parse-bat-config-config-js-quot-issued-td3995703.html

something like:

```
parse.bat "config=config.js" // arguments need to be enclosed in quotes
```

This will work with basePaths for example like:

``` javascript
basePath: 'C:/opt/dojosrc/dojo-release-1.9.1-src',
// or
basePath: 'C:\\opt\\dojosrc\\dojo-release-1.9.1-src',
```

I've tested this on Linux and Win (with shell, cmd and node), you may want to test OSX too though I see no reason it'd fail. 
